### PR TITLE
Take-home Ops project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,6 @@ COPY ["webapp", "./webapp"]
 COPY ["README.md", "stack.yaml", "package.yaml", "."]
 RUN ["stack", "build"]
 COPY . .
+EXPOSE 8080
 ENTRYPOINT ["stack"]
 CMD ["run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /opt/meatbar
 COPY ["app", "./app"]
 COPY ["src", "./src"]
 COPY ["webapp", "./webapp"]
-COPY ["README.md", "stack.yaml", "package.yaml", "."]
+COPY ["README.md", "stack.yaml", "package.yaml", "./"]
 RUN ["stack", "build"]
 COPY . .
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM haskell:8.8.4
+WORKDIR /opt/meatbar
+COPY ["app", "./app"]
+COPY ["src", "./src"]
+COPY ["webapp", "./webapp"]
+COPY ["README.md", "stack.yaml", "package.yaml", "."]
+RUN ["stack", "build"]
+COPY . .
+ENTRYPOINT ["stack"]
+CMD ["run"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3.9"
+services:
+  meatbar:
+    build: .
+    ports:
+      - "8080:8080"


### PR DESCRIPTION
The exercise is roughly:

1. Dockerize `meatbar`
2. Push images to ECR or Heroku
3. Set up ECS in AWS console to point to image
4. Deploy within a 2-instance ECS fargate cluster via CloudFormation
5. Use platform-cli instead of CloudFormation